### PR TITLE
Make the task compatible with npm@3

### DIFF
--- a/tasks/raml_cop.js
+++ b/tasks/raml_cop.js
@@ -10,8 +10,8 @@
 
 var async     = require('async');
 var raml      = require('raml-parser');
-var utils     = require('../node_modules/raml-cop/src/lib/utils.js');
-var reporter  = require('../node_modules/raml-cop/src/lib/reporter.js');
+var utils     = require('raml-cop/src/lib/utils.js');
+var reporter  = require('raml-cop/src/lib/reporter.js');
 
 module.exports = function(grunt) {
 


### PR DESCRIPTION
Flattened install structure imposed by npm@3 does not install raml-cop under node_modules folder
